### PR TITLE
MODEL REFACTORING 1: Stat Block as Hash Map

### DIFF
--- a/src/main/tst/Tester.java
+++ b/src/main/tst/Tester.java
@@ -22,7 +22,7 @@ public class Tester {
 
 
     // Testing who goes first | TODO: REFACTOR!
-    public static void testGoFirstMethod(int iterations){
+    /*public static void testGoFirstMethod(int iterations){
         Slime slime = new Slime(1);
         Player player = new Player("Test Guy");
         BattleScene bsc = new BattleScene(player,slime);
@@ -113,7 +113,7 @@ public class Tester {
             System.out.println(ANSI_RED + "FAILURE" + ANSI_RESET);
         }
 
-    }
+    }*/
 
     // The tester main method
     public static void main(String[] args){

--- a/src/main/tst/Tester.java
+++ b/src/main/tst/Tester.java
@@ -122,7 +122,7 @@ public class Tester {
         Player player = new Player("Player");
         player.getPlayerInventory().put(new Healable(HealingItem.SMALL_HEALTH_POTION));
         Enemy slime = new Slime(1);
-        System.out.println(slime);
+        System.out.println(slime.getEXPAmount());
         JTextArea textLog = new JTextArea();
 
 

--- a/src/main/tst/Tester.java
+++ b/src/main/tst/Tester.java
@@ -122,6 +122,7 @@ public class Tester {
         Player player = new Player("Player");
         player.getPlayerInventory().put(new Healable(HealingItem.SMALL_HEALTH_POTION));
         Enemy slime = new Slime(1);
+        System.out.println(slime);
         JTextArea textLog = new JTextArea();
 
 

--- a/src/model/bsc/BattleScene.java
+++ b/src/model/bsc/BattleScene.java
@@ -32,7 +32,7 @@ public class BattleScene {
         this.player = player;
         this.inBattle = true;
         this.isPlayerTurn = false;
-        this.firstGoer = determineWhoGoesFirst(player,enemy);
+        //this.firstGoer = determineWhoGoesFirst(player,enemy);
 
         // Debug
         System.out.println("Starting battle...");
@@ -58,7 +58,7 @@ public class BattleScene {
     // -- Helper Methods --
     // method that determines who goes next in a battle
     // TODO: Refactor...
-    public Entity determineWhoGoesFirst(Entity entity1, Entity entity2){
+    /*public Entity determineWhoGoesFirst(Entity entity1, Entity entity2){
         Entity goer;
         StatBlock entity1Stats = entity1.getEntityStatBlock();
         int entity1Speed = entity1.getEntityStatBlock().getEffectiveSpeed();
@@ -101,7 +101,7 @@ public class BattleScene {
 
         // Debug
         System.out.println(attacker.getEntityName() + " attacks " + target.getEntityName());
-    }
+    }*/
 
 
 

--- a/src/model/ety/Entity.java
+++ b/src/model/ety/Entity.java
@@ -1,8 +1,9 @@
 package model.ety;
 
+import java.util.EnumMap;
 import java.util.Random;
 
-/*
+/**
  * This class is the abstract, non-concrete entity class that all entities (in this case slime and player, since
  * there are no others, extend from).
  * It provides all parameters for entities as well as most functionality for entities.
@@ -31,45 +32,33 @@ public abstract class Entity {
 
 
     // === OTHER METHODS ===
-
-    /*// -- Battle methods --
-    // method to check if dead
-    public boolean isDead(){return this.getEntityStatBlock().getEntityCurrentHealth() <= 0;}
-
-    // method to guard
+    /**
+     * Void method that sets the enemies temporary defense to a higher value if they guard. This value will be added in
+     * other methods to calculate the full defense value, which will be used in all battle calculations. Right now,
+     * it just sets that as the temporary value. If the entity's defense is 0, it sets the temporary value to 1.
+     * */
     public void guard(){
-        int defense = this.entityStatBlock.getEntityDefense();
+        int defense = this.getEntityStatBlock().getStatsMap().get(Stats.DEFENSE);
         if(defense == 0){
-            this.entityStatBlock.setTempDefenseMod(1);
+            this.getEntityStatBlock().increaseTemporaryDefense(1);
         } else {
-            this.entityStatBlock.setTempDefenseMod((int) Math.ceil(defense / 2.0));
+            this.getEntityStatBlock().increaseTemporaryDefense((int) Math.ceil(defense / 2.0));
         }
-
-        // Debug
-        System.out.println((int) Math.ceil(defense / 2.0));
-        System.out.println(this.getEntityStatBlock().getEffectiveDefense());
     }
 
-    // method to calculate run chance using speed, returns boolean of run success or not | TODO: Devise a test for this
-    public boolean run(Entity runFrom){
-        int runnerSpeed = this.getEntityStatBlock().getEffectiveSpeed();
-        int runFromSpeed = runFrom.getEntityStatBlock().getEffectiveSpeed();
+    /**
+     * Returns the double chance value of an entity being able to escape. It will be used in another method in battle
+     * scene to return a boolean based on if runnerSpeed <= random between 1 and totalSpeed+1.
+     * Currently, it just returns the double chance value.
+     * If both speeds are 0, it returns 0.5 for an equal chance of escape or non-escape.
+     */
+    public double calculateEscapeChance(int opposingSpeed){
+        StatBlock thisStatBlock = this.getEntityStatBlock();
+        int runnerSpeed = thisStatBlock.calcFullSpeed();
 
-        int totalSpeed =  runnerSpeed + runFromSpeed;
+        int totalSpeed = runnerSpeed + opposingSpeed;
+        if(totalSpeed == 0) return 0.5;
 
-        // Debug
-        System.out.println(totalSpeed);
-
-        Random rand = new Random();
-        int runSuccessNum = rand.nextInt(1,totalSpeed+1);
-
-        // Debug
-        System.out.println(runSuccessNum);
-
-        // Should give a ~50% chance to escape when speeds are the same
-        return runSuccessNum <= runnerSpeed;
-    }*/
-
-
-
+        return (double) runnerSpeed / totalSpeed;
+    }
 }

--- a/src/model/ety/Entity.java
+++ b/src/model/ety/Entity.java
@@ -14,6 +14,7 @@ public abstract class Entity {
     // === VARIABLES AND FIELDS ===
     private final String entityName, entityDescription;
     private final StatBlock entityStatBlock;
+    private LifeState entityState;
 
 
     // === ENTITY CONSTRUCTOR ===
@@ -21,6 +22,7 @@ public abstract class Entity {
         this.entityName = name;
         this.entityDescription = description;
         this.entityStatBlock = statBlock;
+        this.entityState = LifeState.ALIVE;
     }
 
     // === GETTERS AND SETTERS ===
@@ -29,6 +31,8 @@ public abstract class Entity {
     public String getEntityDescription() {return this.entityDescription;}
 
     public StatBlock getEntityStatBlock() {return this.entityStatBlock;}
+
+    public LifeState getEntityState() {return this.entityState;}
 
 
     // === ENTITY METHODS ===
@@ -97,5 +101,24 @@ public abstract class Entity {
     /**
      * This method sets the entity's state to the input. That input set does not exist yet.
      * */
-    public void changeState(){}
+    // QUESTION: Should I just use a setter?
+    public void changeState(LifeState state){
+        this.entityState = state;
+    }
+
+
+    /// TO STRING OF ENTITY
+    @Override
+    public String toString(){
+        // QUESTION: is this... readable and good?
+        return String.format("%s%n%s%n%n%s%n%nState: %s",
+                entityName,
+                entityDescription,
+                entityStatBlock,
+                entityState
+        );
+    }
+
+
+
 }

--- a/src/model/ety/Entity.java
+++ b/src/model/ety/Entity.java
@@ -32,7 +32,7 @@ public abstract class Entity {
 
     // === OTHER METHODS ===
 
-    // -- Battle methods --
+    /*// -- Battle methods --
     // method to check if dead
     public boolean isDead(){return this.getEntityStatBlock().getEntityCurrentHealth() <= 0;}
 
@@ -68,7 +68,7 @@ public abstract class Entity {
 
         // Should give a ~50% chance to escape when speeds are the same
         return runSuccessNum <= runnerSpeed;
-    }
+    }*/
 
 
 

--- a/src/model/ety/Entity.java
+++ b/src/model/ety/Entity.java
@@ -31,7 +31,33 @@ public abstract class Entity {
     public StatBlock getEntityStatBlock() {return this.entityStatBlock;}
 
 
-    // === OTHER METHODS ===
+    // === ENTITY METHODS ===
+    /**
+     * Method for an entity to attack another entity. Returns an int that is the value of the damage done by this
+     * entity.
+     * */
+    public int attack(){
+        StatBlock stats = this.getEntityStatBlock();
+
+        int finalAttack = stats.calcFullAttack();
+        // Will be modified with anything else that increases attack; weapons, etc.
+
+        return finalAttack;
+    }
+
+    /**
+     * Method that calculates final damage based on resistances, statuses, etc. and then applies that to the entity's
+     * stat block. Does not return anything, merely changes the stat block values.
+     * */
+    public void takeDamage(int damage){
+        StatBlock stats = this.getEntityStatBlock();
+        int damageReduction = stats.calcFullDefense();
+
+        int finalDamage = damage - damageReduction;
+
+        stats.reduceCurrentHealth(finalDamage);
+    }
+
     /**
      * Void method that sets the enemies temporary defense to a higher value if they guard. This value will be added in
      * other methods to calculate the full defense value, which will be used in all battle calculations. Right now,
@@ -45,6 +71,12 @@ public abstract class Entity {
             this.getEntityStatBlock().increaseTemporaryDefense((int) Math.ceil(defense / 2.0));
         }
     }
+
+    /**
+     * Method that will eventually be populated for the entity to use an item.
+     * TODO: figure out handling of different item types. Enum?
+     * */
+    public void useItem(){}
 
     /**
      * Returns the double chance value of an entity being able to escape. It will be used in another method in battle
@@ -61,4 +93,9 @@ public abstract class Entity {
 
         return (double) runnerSpeed / totalSpeed;
     }
+
+    /**
+     * This method sets the entity's state to the input. That input set does not exist yet.
+     * */
+    public void changeState(){}
 }

--- a/src/model/ety/LifeState.java
+++ b/src/model/ety/LifeState.java
@@ -1,0 +1,28 @@
+package model.ety;
+
+///  This class is an enum for which state of life an entity is in: alive or dead.
+/// NOTE: This serves as a way to expand for future, in case more are needed; respawning, etc.
+public enum LifeState {
+
+    // === VALUES OF THE ENUM ===
+    ALIVE("ALIVE"),
+    DEAD("DEAD");
+
+
+    // === VARIABLES OF ENUM ===
+    private String label;
+
+
+    // === CONSTRUCTOR ===
+    LifeState(String title){
+        this.label = title;
+    }
+
+
+    // === METHODS ===
+    @Override
+    public String toString(){
+        return String.format("%s",this.label);
+    }
+
+}

--- a/src/model/ety/Player.java
+++ b/src/model/ety/Player.java
@@ -32,7 +32,7 @@ public class Player extends Entity{
     // method to use an item
     public void useItem(Item item){
         // TEMP: hard coded to just use healing items. Will need to change with expanded item infrastructure
-        this.getEntityStatBlock().takeHeal(item.getUsed());
+        //this.getEntityStatBlock().takeHeal(item.getUsed());
         this.playerInventory.remove(item);
     }
 

--- a/src/model/ety/Player.java
+++ b/src/model/ety/Player.java
@@ -2,10 +2,14 @@ package model.ety;
 
 import model.itm.Item;
 
+import java.util.EnumMap;
+import java.util.Random;
+
 public class Player extends Entity{
 
     // === VARIABLES AND FIELDS ===
     private final Inventory playerInventory;
+    private int currentEXP, expForNextLevel;
 
     // === CONSTRUCTOR FOR PLAYER ===
     public Player(String name){
@@ -20,6 +24,18 @@ public class Player extends Entity{
                         1
                 ));
         this.playerInventory = new Inventory(50);
+        this.currentEXP = 0;
+        this.expForNextLevel = calculateNextLevelEXP();
+    }
+
+    // === CONSTRUCTOR METHODS ===
+    private int calculateNextLevelEXP(){
+        int level = this.getEntityStatBlock().getStatsMap().get(Stats.LEVEL);
+
+        // Some method for level growth; for now just linear
+        // === CONSTANTS ===
+        int expGrowthMod = 50;
+        return level * expGrowthMod;
     }
 
 
@@ -28,6 +44,52 @@ public class Player extends Entity{
 
 
     // === OTHER METHODS ===
+    public void gainEXP(int expGain){
+        this.currentEXP = this.currentEXP + expGain;
+    }
+
+
+
+    /**
+     * Method to level up the player. Randomly increases stats by a certain amount. Right now just 1-5.
+     * */
+    public void levelUp(){
+        int upperBound = 5;
+        int lowerBound = 1;
+        Random statIncrease = new Random();
+        EnumMap<Stats,Integer> stats = this.getEntityStatBlock().getStatsMap();
+
+        stats.replace(Stats.LEVEL,stats.get(Stats.LEVEL) + 1);
+        int healthIncrease = statIncrease.nextInt(lowerBound,upperBound);
+
+        int oldHealth = stats.get(Stats.MAX_HEALTH);
+        int newHealth = oldHealth + healthIncrease;
+        stats.replace(Stats.MAX_HEALTH,newHealth);
+        stats.replace(Stats.CURRENT_HEALTH,newHealth);
+
+        int attackIncrease = statIncrease.nextInt(lowerBound,upperBound);
+
+        int oldAttack = stats.get(Stats.ATTACK);
+        int newAttack = oldAttack + attackIncrease;
+        stats.replace(Stats.ATTACK,newAttack);
+
+        int defenseIncrease = statIncrease.nextInt(lowerBound,upperBound);
+
+        int oldDefense = stats.get(Stats.DEFENSE);
+        int newDefense = oldDefense + defenseIncrease;
+        stats.replace(Stats.DEFENSE,newDefense);
+
+        int speedIncrease = statIncrease.nextInt(lowerBound,upperBound);
+
+        int oldSpeed = stats.get(Stats.SPEED);
+        int newSpeed = oldSpeed + speedIncrease;
+        stats.replace(Stats.SPEED,newSpeed);
+
+        this.expForNextLevel = calculateNextLevelEXP();
+    }
+
+
+
     // -- Item methods --
     // method to use an item
     public void useItem(Item item){

--- a/src/model/ety/StatBlock.java
+++ b/src/model/ety/StatBlock.java
@@ -4,13 +4,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
 
+/**
+ * This class is the stat block for entities. It contains only a Hash Map, and is a separate class so that all stat
+ * related calculations take place here instead of within the more general Entity class, and so they can have separate
+ * to String values.
+ * NOTE: It might be a good idea to keep an original version of the to String if I need to see the instance value or
+ *    see the information without printing everything else. I'm not too sure, but that might be a toLog method.
+ **********************************************************************************************************************/
+
 public class StatBlock {
 
     // TODO: Should eventually be a Hash Map
 
     // === VARIABLES AND FIELDS ===
     private final EnumMap<Stats,Integer> statsMap;
-
 
     // === CONSTRUCTOR FOR STAT BLOCK ===
     public StatBlock(int level, int health, int attack, int defense, int speed){
@@ -30,14 +37,37 @@ public class StatBlock {
 
     }
 
-    // ===
+    // === GETTER ===
+    public EnumMap<Stats,Integer> getStatsMap() {return this.statsMap;}
+
+    // === METHODS ===
+    public void levelUp(){this.statsMap.replace(Stats.LEVEL,this.statsMap.get(Stats.LEVEL) + 1);}
+
+    public void levelDown(){this.statsMap.replace(Stats.LEVEL,this.statsMap.get(Stats.LEVEL) - 1);}
+
+    public void takeDamage(int damage){
+        this.statsMap.replace(Stats.CURRENT_HEALTH,this.statsMap.get(Stats.CURRENT_HEALTH) - damage);
+        if(this.statsMap.get(Stats.CURRENT_HEALTH) <= 0){
+            this.statsMap.replace(Stats.CURRENT_HEALTH, 0);
+        }
+    }
+
+    public void healHealth(int heal){
+        this.statsMap.replace(Stats.CURRENT_HEALTH,this.statsMap.get(Stats.CURRENT_HEALTH) + heal);
+        if(this.statsMap.get(Stats.CURRENT_HEALTH) >= this.statsMap.get(Stats.MAX_HEALTH)){
+            this.statsMap.replace(Stats.CURRENT_HEALTH,statsMap.get(Stats.MAX_HEALTH));
+        }
+    }
+
+
+    ///  To String for the Stat Block of the Entity
     @Override
-    public String toString(){
+    public String toString(){ //TODO: NEED A BETTER WAY TO DO THIS
         ArrayList<String> rawStatsStrings = new ArrayList<>();
         ArrayList<String> rawStatsValues = new ArrayList<>();
 
         for(Stats stat : this.statsMap.keySet()){
-            String statString = stat.toString(); // NOTE: May need to add this in the enum
+            String statString = stat.toString();
 
             rawStatsStrings.add(statString);
         }
@@ -51,11 +81,11 @@ public class StatBlock {
 
         String[] finalDisplay = new String[]{
                 rawStatsStrings.get(0) + rawStatsValues.get(0),                      //Level
-                "HEALTH: " + rawStatsValues.get(2) + "/" + rawStatsValues.get(1),           //Health
+                "HEALTH: " + rawStatsValues.get(2) + "/" + rawStatsValues.get(1),    //Health
                 rawStatsStrings.get(3) + rawStatsValues.get(3),                      //Attack
                 rawStatsStrings.get(4) + rawStatsValues.get(4),                      //Defense
                 rawStatsStrings.get(5) + rawStatsValues.get(5),                      //Speed
-        };
+        }; //TODO: Add the temporary values to this printing... might make things complex
 
         return Arrays.toString(finalDisplay)
                 .replace(",","\n")
@@ -64,5 +94,6 @@ public class StatBlock {
                 .trim();
 
     }
+
 
 }

--- a/src/model/ety/StatBlock.java
+++ b/src/model/ety/StatBlock.java
@@ -48,14 +48,14 @@ public class StatBlock {
 
     public void levelDown(){this.statsMap.replace(Stats.LEVEL,this.statsMap.get(Stats.LEVEL) - 1);}
 
-    public void takeDamage(int damage){
+    public void reduceCurrentHealth(int damage){
         this.statsMap.replace(Stats.CURRENT_HEALTH,this.statsMap.get(Stats.CURRENT_HEALTH) - damage);
         if(this.statsMap.get(Stats.CURRENT_HEALTH) <= 0){
             this.statsMap.replace(Stats.CURRENT_HEALTH, 0);
         }
     }
 
-    public void healHealth(int heal){
+    public void increaseCurrentHealth(int heal){
         this.statsMap.replace(Stats.CURRENT_HEALTH,this.statsMap.get(Stats.CURRENT_HEALTH) + heal);
         if(this.statsMap.get(Stats.CURRENT_HEALTH) >= this.statsMap.get(Stats.MAX_HEALTH)){
             this.statsMap.replace(Stats.CURRENT_HEALTH,statsMap.get(Stats.MAX_HEALTH));

--- a/src/model/ety/StatBlock.java
+++ b/src/model/ety/StatBlock.java
@@ -2,182 +2,67 @@ package model.ety;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumMap;
 
 public class StatBlock {
 
     // TODO: Should eventually be a Hash Map
 
     // === VARIABLES AND FIELDS ===
-    private int entityLevel, entityCurrentHealth, entityMaxHealth, entityAttack, entityDefense, entitySpeed;
-    private int tempHealthMod, tempAttackMod, tempDefenseMod, tempSpeedMod;
+    private final EnumMap<Stats,Integer> statsMap;
 
 
     // === CONSTRUCTOR FOR STAT BLOCK ===
-    public StatBlock(int level, int maxHealth, int attack, int defense, int speed){
-        this.entityLevel = level;
-        this.entityMaxHealth = maxHealth;
-        this.entityCurrentHealth = maxHealth;
-        this.entityAttack = attack;
-        this.entityDefense = defense;
-        this.entitySpeed = speed;
-        this.tempHealthMod = 0;
-        this.tempAttackMod = 0;
-        this.tempDefenseMod = 0;
-        this.tempSpeedMod = 0;
+    public StatBlock(int level, int health, int attack, int defense, int speed){
+
+        this.statsMap = new EnumMap<>(Stats.class){{
+            put(Stats.LEVEL,level);
+            put(Stats.MAX_HEALTH,health);
+            put(Stats.CURRENT_HEALTH,health);
+            put(Stats.ATTACK,attack);
+            put(Stats.DEFENSE,defense);
+            put(Stats.SPEED,speed);
+            put(Stats.TEMP_HEALTH_BONUS,0);
+            put(Stats.TEMP_ATTACK_BONUS,0);
+            put(Stats.TEMP_DEFENSE_BONUS,0);
+            put(Stats.TEMP_SPEED_BONUS,0);
+        }};
+
     }
 
-    // === TO STRING ===
+    // ===
     @Override
     public String toString(){
-        String[] statsArray = new String[]{
-                "Level: " + this.entityLevel,
-                "Health: " + this.entityCurrentHealth + "/" + this.entityMaxHealth,
-                "Attack: " + this.entityAttack,
-                "Defense: " + this.entityDefense,
-                "Speed: " + this.entitySpeed,
-                "Temporary HP: " + this.tempHealthMod,
-                "Temporary Def: " + this.tempDefenseMod,
-                "Temporary Spd: " + this.tempSpeedMod
+        ArrayList<String> rawStatsStrings = new ArrayList<>();
+        ArrayList<String> rawStatsValues = new ArrayList<>();
+
+        for(Stats stat : this.statsMap.keySet()){
+            String statString = stat.toString(); // NOTE: May need to add this in the enum
+
+            rawStatsStrings.add(statString);
+        }
+
+
+        for(Stats stat : this.statsMap.keySet()){
+            String valueString = this.statsMap.get(stat).toString();
+
+            rawStatsValues.add(valueString);
+        }
+
+        String[] finalDisplay = new String[]{
+                rawStatsStrings.get(0) + rawStatsValues.get(0),                      //Level
+                "HEALTH: " + rawStatsValues.get(2) + "/" + rawStatsValues.get(1),           //Health
+                rawStatsStrings.get(3) + rawStatsValues.get(3),                      //Attack
+                rawStatsStrings.get(4) + rawStatsValues.get(4),                      //Defense
+                rawStatsStrings.get(5) + rawStatsValues.get(5),                      //Speed
         };
 
-        return Arrays.toString(statsArray)
+        return Arrays.toString(finalDisplay)
                 .replace(",","\n")
                 .replace("[","")
                 .replace("]","")
                 .trim();
+
     }
-
-
-    // === GETTERS AND SETTERS ===
-    public int getEntityLevel() {return this.entityLevel;}
-    public void setEntityLevel(int level) {this.entityLevel = level;}
-
-    public int getEntityCurrentHealth() {return this.entityCurrentHealth;}
-    public void setEntityCurrentHealth(int health) {this.entityCurrentHealth = health;}
-
-    public int getEntityAttack() {return this.entityAttack;}
-    public void setEntityAttack(int attack) {this.entityAttack = attack;}
-
-    public int getEntityDefense() {return this.entityDefense;}
-    public void setEntityDefense(int defense) {this.entityDefense = defense;}
-
-    public int getEntitySpeed() {return this.entitySpeed;}
-    public void setEntitySpeed(int speed) {this.entitySpeed = speed;}
-
-    public int getEntityMaxHealth() {return this.entityMaxHealth;}
-    public void setEntityMaxHealth(int health) {this.entityMaxHealth = health;}
-
-    public int getTempHealthMod() {return tempHealthMod;}
-    public void setTempHealthMod(int tempHealthMod) {this.tempHealthMod = tempHealthMod;}
-
-    public int getTempAttackMod() {return tempAttackMod;}
-    public void setTempAttackMod(int tempAttackMod) {this.tempAttackMod = tempAttackMod;}
-
-    public int getTempDefenseMod() {return tempDefenseMod;}
-    public void setTempDefenseMod(int tempDefenseMod) {this.tempDefenseMod = tempDefenseMod;}
-
-    public int getTempSpeedMod() {return tempSpeedMod;}
-    public void setTempSpeedMod(int tempSpeedMod) {this.tempSpeedMod = tempSpeedMod;}
-
-    // === OTHER METHODS ===
-
-    // -- Basic Methods -- | TODO: do all other stat modifications that might happen
-    // method that returns the resulting health from subtracting param from currentHealth
-    private int calculateResultingHealth(int damage){
-        return Math.max(this.getEntityCurrentHealth() - damage, 0);
-    }
-
-    // Method for entity to take in a value and apply it as damage to its current health
-    // NOTE: Clamped this value as of 7/9/25 commit in case of unintended behavior; clamps health no less than 0
-    public void takeDamage(int damage) {
-        this.setEntityCurrentHealth(Math.max(calculateResultingHealth(damage),0));
-    }
-
-    // Method for entity to calculate the resulting health by adding a value
-    private int calculateHealthFromHeal(int heal) { return Math.max(this.getEntityCurrentHealth() + heal,0);}
-
-    // Method for entity to take in a value and apply it as heal to its current health
-    // NOTE: Clamped this value as of 7/9/25 commit in case of unintended behavior; sets health no greater than max
-    public void takeHeal(int heal) {
-        this.setEntityCurrentHealth(Math.min(calculateHealthFromHeal(heal),this.getEffectiveMaxHealth()));
-    }
-
-    // method that returns the next level
-    private int getNextLevel(){
-        return this.getEntityLevel() + 1;
-    }
-
-    // method that returns the previous level, but cannot go below 0
-    private int getLastLevel(){
-        return Math.max(this.getEntityLevel() - 1,0);
-    }
-
-    // method that increments the entity level by one
-    public void incrementLevel(){
-        this.setEntityLevel(getNextLevel());
-    }
-
-    // method that decrements the entity level by one
-    public void decrementLevel(){
-        this.setEntityLevel(getLastLevel());
-    }
-
-    // method to reset all temporary stats
-    public void resetTempStats(){
-        this.tempHealthMod = 0;
-        this.tempAttackMod = 0;
-        this.tempDefenseMod = 0;
-        this.tempSpeedMod = 0;
-    }
-
-
-    // -- Comparison Methods --
-    // method that compares level to param and returns higher value
-    public int compareLevel(int comparison){
-        return Math.max(this.getEntityLevel(),comparison);
-    }
-
-    // method that compares max health to param and returns higher value
-    public int compareMaxHealth(int comparison){
-        return Math.max(this.getEntityMaxHealth(),comparison);
-    }
-
-    // method that compares current health to param and returns higher value
-    public int compareCurrentHealth(int comparison){
-        return Math.max(this.getEntityCurrentHealth(),comparison);
-    }
-
-    // method that compares attack to param and returns higher value
-    public int compareAttack(int comparison){
-        return Math.max(this.getEntityAttack(),comparison);
-    }
-
-    // method that compares defense to param and returns higher value
-    public int compareDefense(int comparison){
-        return Math.max(this.getEffectiveDefense(),comparison);
-    }
-
-    // method that compares speed to param and returns higher value
-    public boolean compareSpeedTo(int comparison){
-        return this.getEffectiveSpeed() > comparison;
-    }
-
-
-    // -- Modifier Methods --
-    // method to get the effective maxHealth
-    public int getEffectiveMaxHealth() {return this.entityMaxHealth + this.tempHealthMod;}
-
-    // method to get the effective attack
-    public int getEffectiveAttack() {return this.entityAttack + this.tempAttackMod;}
-
-    // method to get the effective defense
-    public int getEffectiveDefense() {return this.entityDefense + this.tempDefenseMod;}
-
-    // method to get the effective speed
-    public int getEffectiveSpeed() {return this.entitySpeed + this.tempSpeedMod;}
-
-
-
-
 
 }

--- a/src/model/ety/StatBlock.java
+++ b/src/model/ety/StatBlock.java
@@ -120,43 +120,23 @@ public class StatBlock {
     }
 
 
-
-
-
-
-
     ///  To String for the Stat Block of the Entity
     @Override
-    public String toString(){ //TODO: NEED A BETTER WAY TO DO THIS
-        ArrayList<String> rawStatsStrings = new ArrayList<>();
-        ArrayList<String> rawStatsValues = new ArrayList<>();
+    public String toString(){
+        int level = statsMap.get(Stats.LEVEL);
+        int currentHealth = statsMap.get(Stats.CURRENT_HEALTH);
+        int maxHealth = statsMap.get(Stats.MAX_HEALTH);
+        int healthBonus = statsMap.get(Stats.TEMP_HEALTH_BONUS);
+        int attack = statsMap.get(Stats.ATTACK);
+        int attackBonus = statsMap.get(Stats.TEMP_ATTACK_BONUS);
+        int defense = statsMap.get(Stats.DEFENSE);
+        int defenseBonus = statsMap.get(Stats.TEMP_DEFENSE_BONUS);
+        int speed = statsMap.get(Stats.SPEED);
+        int speedBonus = statsMap.get(Stats.TEMP_SPEED_BONUS);
 
-        for(Stats stat : this.statsMap.keySet()){
-            String statString = stat.toString();
-
-            rawStatsStrings.add(statString);
-        }
-
-
-        for(Stats stat : this.statsMap.keySet()){
-            String valueString = this.statsMap.get(stat).toString();
-
-            rawStatsValues.add(valueString);
-        }
-
-        String[] finalDisplay = new String[]{
-                rawStatsStrings.get(0) + rawStatsValues.get(0),                      //Level
-                "HEALTH: " + rawStatsValues.get(2) + "/" + rawStatsValues.get(1),    //Health
-                rawStatsStrings.get(3) + rawStatsValues.get(3),                      //Attack
-                rawStatsStrings.get(4) + rawStatsValues.get(4),                      //Defense
-                rawStatsStrings.get(5) + rawStatsValues.get(5),                      //Speed
-        }; //TODO: Add the temporary values to this printing... might make things complex
-
-        return Arrays.toString(finalDisplay)
-                .replace(",","\n")
-                .replace("[","")
-                .replace("]","")
-                .trim();
+        return String.format("Level: %d%n%nHealth: %d/%d + %d%nAttack: %d + %d%nDefense: %d + %d%nSpeed: %d + %d",
+                level,currentHealth,maxHealth,healthBonus,attack,attackBonus,defense,defenseBonus,speed,speedBonus
+        );
 
     }
 

--- a/src/model/ety/StatBlock.java
+++ b/src/model/ety/StatBlock.java
@@ -3,6 +3,7 @@ package model.ety;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
+import java.util.Spliterator;
 
 /**
  * This class is the stat block for entities. It contains only a Hash Map, and is a separate class so that all stat
@@ -41,6 +42,8 @@ public class StatBlock {
     public EnumMap<Stats,Integer> getStatsMap() {return this.statsMap;}
 
     // === METHODS ===
+    public boolean isDead() {return this.statsMap.get(Stats.CURRENT_HEALTH) <= 0;}
+
     public void levelUp(){this.statsMap.replace(Stats.LEVEL,this.statsMap.get(Stats.LEVEL) + 1);}
 
     public void levelDown(){this.statsMap.replace(Stats.LEVEL,this.statsMap.get(Stats.LEVEL) - 1);}
@@ -58,6 +61,68 @@ public class StatBlock {
             this.statsMap.replace(Stats.CURRENT_HEALTH,statsMap.get(Stats.MAX_HEALTH));
         }
     }
+
+    public int calcFullHealth(){
+        return this.statsMap.get(Stats.MAX_HEALTH) + this.statsMap.get(Stats.TEMP_HEALTH_BONUS);
+    }
+
+    public int calcFullAttack(){
+        return this.statsMap.get(Stats.ATTACK) + this.statsMap.get(Stats.TEMP_ATTACK_BONUS);
+    }
+
+    public int calcFullDefense(){
+        return this.statsMap.get(Stats.DEFENSE) + this.statsMap.get(Stats.TEMP_DEFENSE_BONUS);
+    }
+
+    public int calcFullSpeed(){
+        return this.statsMap.get(Stats.SPEED) + this.statsMap.get(Stats.TEMP_SPEED_BONUS);
+    }
+
+    public void increaseTemporaryHealth(int increase){
+        this.statsMap.replace(Stats.TEMP_HEALTH_BONUS,this.statsMap.get(Stats.TEMP_HEALTH_BONUS) + increase);
+    }
+
+    public void increaseTemporaryAttack(int increase){
+        this.statsMap.replace(Stats.TEMP_ATTACK_BONUS,this.statsMap.get(Stats.TEMP_ATTACK_BONUS) + increase);
+    }
+
+    public void increaseTemporaryDefense(int increase){
+        this.statsMap.replace(Stats.TEMP_DEFENSE_BONUS,this.statsMap.get(Stats.TEMP_DEFENSE_BONUS) + increase);
+    }
+
+    public void increaseTemporarySpeed(int increase){
+        this.statsMap.replace(Stats.TEMP_SPEED_BONUS,this.statsMap.get(Stats.TEMP_SPEED_BONUS) + increase);
+    }
+
+    // === COMPARE METHODS ===
+    public int compareLevel(int comparedLevel){
+        return this.statsMap.get(Stats.LEVEL) - comparedLevel;
+    }
+
+    public int compareMaxHealth(int comparedHealth){
+        return this.statsMap.get(Stats.MAX_HEALTH) - comparedHealth;
+    }
+
+    public int compareCurrentHealth(int comparedHealth){
+        return this.statsMap.get(Stats.CURRENT_HEALTH) - comparedHealth;
+    }
+
+    public int compareAttack(int comparedAttack){
+        return this.statsMap.get(Stats.ATTACK) - comparedAttack;
+    }
+
+    public int compareDefense(int comparedDefense){
+        return this.statsMap.get(Stats.DEFENSE) - comparedDefense;
+    }
+
+    public int compareSpeed(int comparedSpeed){
+        return this.statsMap.get(Stats.SPEED) - comparedSpeed;
+    }
+
+
+
+
+
 
 
     ///  To String for the Stat Block of the Entity

--- a/src/model/ety/Stats.java
+++ b/src/model/ety/Stats.java
@@ -1,0 +1,41 @@
+package model.ety;
+
+/***********************************************************************************************************************
+ * This enum is the stats for enemies to make them easier to refer to in the coming stat block hash map.
+ *
+ *
+ **********************************************************************************************************************/
+
+public enum Stats {
+
+    // === VALUES FOR ENUM ===
+
+    // basic stats
+    LEVEL("LEVEL: "),
+    MAX_HEALTH("UNUSED "),
+    CURRENT_HEALTH("HEALTH: "),
+    ATTACK("ATTACK: "),
+    DEFENSE("DEFENSE: "),
+    SPEED("SPEED: "),
+
+    // temporary stats | NOTE: these likely won't be printed in the final version
+    TEMP_HEALTH_BONUS("UNUSED "),
+    TEMP_ATTACK_BONUS("UNUSED "),
+    TEMP_DEFENSE_BONUS("UNUSED "),
+    TEMP_SPEED_BONUS("UNUSED ");
+
+    // === VARIABLES AND FIELDS ===
+    private final String label;
+
+    // === CONSTRUCTOR ===
+    Stats(String title){
+        this.label = title;
+    }
+
+    // === METHODS ===
+    public String toString(){
+        return this.label;
+    }
+
+
+}

--- a/src/model/ety/enemy/Enemy.java
+++ b/src/model/ety/enemy/Enemy.java
@@ -3,15 +3,37 @@ package model.ety.enemy;
 import model.ety.BattleChoice;
 import model.ety.Entity;
 import model.ety.StatBlock;
+import model.ety.Stats;
+
+import java.util.Random;
 
 public class Enemy extends Entity {
 
+    // === VARIABLES AND FIELDS ===
+    private final int expAmount;
+    private final int expMod;
+
     // === CONSTRUCTOR FOR ENEMY ===
-    public Enemy(String name, String description, StatBlock statBlock){
+    public Enemy(String name, String description, StatBlock statBlock, int expMod){
         super(name, description, statBlock);
+        this.expMod = expMod;
+        this.expAmount = calculateEXP();
     }
 
+    // === GETTERS ===
+    public int getEXPAmount(){return this.expAmount;}
+
     // === OTHER METHODS ===
+    private int calculateEXP(){
+        StatBlock stats = this.getEntityStatBlock();
+        int minEXP = stats.getStatsMap().get(Stats.LEVEL);
+        int maxEXP = minEXP * this.expMod;
+
+        Random rand = new Random();
+        return rand.nextInt(minEXP,maxEXP);
+    }
+
+
 
     // -- Battle Methods --
     public BattleChoice makeBattleChoice(){

--- a/src/model/ety/enemy/Slime.java
+++ b/src/model/ety/enemy/Slime.java
@@ -15,7 +15,9 @@ public class Slime extends Enemy{
                         level,
                         level - 1,
                         level - 1
-                ));
+                ),
+                10
+                );
     }
 
 }

--- a/src/view/BattleDisplayPanel.java
+++ b/src/view/BattleDisplayPanel.java
@@ -60,9 +60,9 @@ public class BattleDisplayPanel extends DisplayPanel {
     }
 
     // method to print health
-    public void printHealth(Entity battler){
-        int currentHealth = battler.getEntityStatBlock().getEntityCurrentHealth();
-        int maxHealth = battler.getEntityStatBlock().getEntityMaxHealth();
+    /*public void printHealth(Entity battler){
+        //int currentHealth = battler.getEntityStatBlock().getEntityCurrentHealth();
+        //int maxHealth = battler.getEntityStatBlock().getEntityMaxHealth();
 
         this.log(battler.getEntityName() + " health: " + currentHealth + "/" + maxHealth +"\n");
     }
@@ -128,7 +128,7 @@ public class BattleDisplayPanel extends DisplayPanel {
     // enemy attack
     public void printEnemyAttack(Entity enemy){
         this.log(enemy.getEntityName() + " attacks!\n");
-    }
+    }*/
 
 
 

--- a/src/view/StatDisplayer.java
+++ b/src/view/StatDisplayer.java
@@ -28,10 +28,7 @@ public class StatDisplayer extends JTextArea {
 
     // === METHODS ===
     private void update(Entity displayedEntity){
-        this.setText(displayedEntity.getEntityName() + "\n" +
-                        displayedEntity.getEntityDescription() + "\n\n" +
-                        displayedEntity.getEntityStatBlock().toString()
-        );
+        this.setText(displayedEntity.toString());
     }
 
 


### PR DESCRIPTION
This commit refactors the Stat Block from merely a collection of integers into a fully fledged Hash Map with everything in it. Things print properly, and I'm no longer printing the temporary stats. Instead, they will just be added whenever they are created.

But this is the first step to making the entity logic much, much cleaner.

One thing I may do far in the future is make the stat block implement an interface for calculating stats. But for now it's all good. Next, I'm going to move on to fixing up the entity code itself outside of the stats.